### PR TITLE
Initial attempt at sendfile(2) implementation

### DIFF
--- a/src/chia_plot_copy.cpp
+++ b/src/chia_plot_copy.cpp
@@ -17,6 +17,11 @@
 #include <stdiox.hpp>
 
 
+#ifndef _WIN32
+#include <sys/sendfile.h>
+#endif
+
+
 size_t g_read_chunk_size = 65536;
 
 
@@ -125,6 +130,7 @@ uint64_t send_file(const std::string& src_path, const std::string& dst_host, con
 			send_bytes(fd, file_name.data(), name_len);
 		}
 
+#ifdef _WIN32
 		std::vector<uint8_t> buffer(g_read_chunk_size * 16);
 		while(true) {
 			const auto num_bytes = fread(buffer.data(), 1, buffer.size(), src);
@@ -134,6 +140,18 @@ uint64_t send_file(const std::string& src_path, const std::string& dst_host, con
 				break;
 			}
 		}
+#else
+		while(true) {
+			const auto num_bytes = ::sendfile(fd, fileno(src), NULL, g_read_chunk_size * 16);
+			if(num_bytes < 0) {
+				throw std::runtime_error("sendfile() failed with: " + get_socket_error_text());
+			}
+			total_bytes += num_bytes;
+			if(num_bytes < g_read_chunk_size * 16) {
+				break;
+			}
+		}
+#endif
 	} catch(...) {
 		CLOSESOCKET(fd);
 		fclose(src);

--- a/src/chia_plot_copy.cpp
+++ b/src/chia_plot_copy.cpp
@@ -142,12 +142,12 @@ uint64_t send_file(const std::string& src_path, const std::string& dst_host, con
 		}
 #else
 		while(true) {
-			const auto num_bytes = ::sendfile(fd, fileno(src), NULL, g_read_chunk_size * 16);
+			const auto num_bytes = ::sendfile(fd, fileno(src), NULL, g_read_chunk_size * 1024);
 			if(num_bytes < 0) {
 				throw std::runtime_error("sendfile() failed with: " + get_socket_error_text());
 			}
 			total_bytes += num_bytes;
-			if(num_bytes < g_read_chunk_size * 16) {
+			if(num_bytes < g_read_chunk_size * 1024) {
 				break;
 			}
 		}


### PR DESCRIPTION
Initial attempt to give us something to talk about at least. I haven't written C/C++ in 20 years so I'm sure you'll have some notes for me. It seems to work?

```
$ time ./chia_plot_copy -t 10.11.10.4 -- /plots/tmp/[01]/*.plot
Starting to copy /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-36-1bffb0433bc5c6361d5d81ea8c0a50b89e4c17183e2ef1c74c6def1625da0d5f.plot ...
Starting to copy /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-39-32ab01e38d4689e7936d1bf4b096ec6676f0c26ed678af2816f175f244448d39.plot ...
Starting to copy /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-37-490a75c24e3d2bd8c7cb4fad460d8d5f174a827d1b20ebc37b019d3cd60531ea.plot ...
Starting to copy /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-37-4d833261a7f68aa208dc0dda1fe4a04b41d22a2287864a7bde42c0aab5b062d3.plot ...
Starting to copy /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-37-054ed13346d90b8da249073e9c0b5872a93ca1369baac869795917c9aba40750.plot ...
Starting to copy /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-36-e8e65dd4b5e24838130c56553ce7ab415ce9381f1359c17c9097adbcce827ed5.plot ...
Starting to copy /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-38-cc9fa2fdfe1a7393a391e81865397e7129ff8a73a8ed92db4767754ac4ea3ec0.plot ...
Starting to copy /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-38-a62dab55dd3f0dbce6df3a7c85bdce65f078896a5a656507f10e08eac36dd3ed.plot ...
Starting to copy /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-39-858eb4bfe5a2c37df3501350dced9f3f3da5369b212809b2988444d0051bf085.plot ...
Finished copy of /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-38-cc9fa2fdfe1a7393a391e81865397e7129ff8a73a8ed92db4767754ac4ea3ec0.plot (16.2842 GiB) took 112.205 sec, 148.613 MB/s
Finished copy of /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-37-054ed13346d90b8da249073e9c0b5872a93ca1369baac869795917c9aba40750.plot (16.2871 GiB) took 118.635 sec, 140.585 MB/s
Finished copy of /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-36-1bffb0433bc5c6361d5d81ea8c0a50b89e4c17183e2ef1c74c6def1625da0d5f.plot (16.2891 GiB) took 119.548 sec, 139.529 MB/s
Finished copy of /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-36-e8e65dd4b5e24838130c56553ce7ab415ce9381f1359c17c9097adbcce827ed5.plot (16.2998 GiB) took 127.397 sec, 131.02 MB/s
Finished copy of /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-37-4d833261a7f68aa208dc0dda1fe4a04b41d22a2287864a7bde42c0aab5b062d3.plot (16.2793 GiB) took 128.732 sec, 129.494 MB/s
Finished copy of /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-39-32ab01e38d4689e7936d1bf4b096ec6676f0c26ed678af2816f175f244448d39.plot (16.3076 GiB) took 129.807 sec, 128.645 MB/s
Finished copy of /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-39-858eb4bfe5a2c37df3501350dced9f3f3da5369b212809b2988444d0051bf085.plot (16.2891 GiB) took 130.516 sec, 127.804 MB/s
Finished copy of /plots/tmp/1/plot-mmx-k30-c9-2023-02-15-19-38-a62dab55dd3f0dbce6df3a7c85bdce65f078896a5a656507f10e08eac36dd3ed.plot (16.3145 GiB) took 131.757 sec, 126.8 MB/s
Finished copy of /plots/tmp/0/plot-mmx-k30-c9-2023-02-15-19-37-490a75c24e3d2bd8c7cb4fad460d8d5f174a827d1b20ebc37b019d3cd60531ea.plot (16.2842 GiB) took 132.544 sec, 125.812 MB/s

real    2m12.551s
user    0m0.241s
sys     0m47.470s
```

It used about 12MB system memory for the above copy operation. 